### PR TITLE
fix: restore table view in pipeline execution screens

### DIFF
--- a/internal/ui/view/view.go
+++ b/internal/ui/view/view.go
@@ -158,7 +158,8 @@ func renderMainContent(m *model.Model) string {
 		// Return the complete view
 		return fmt.Sprintf("%s\n%s\n%s", header, m.Viewport.View(), footer)
 	case constants.ViewExecutingAction:
-		return m.LoadingMsg
+		// Show the table instead of just the loading message
+		return renderTable(m)
 	default:
 		return ""
 	}

--- a/internal/ui/view/view_test.go
+++ b/internal/ui/view/view_test.go
@@ -347,3 +347,81 @@ func TestGetTitleText(t *testing.T) {
 		})
 	}
 }
+
+// TestRenderMainContent tests that the renderMainContent function correctly renders content for different views
+func TestRenderMainContent(t *testing.T) {
+	testCases := []struct {
+		name           string
+		setupModel     func() *model.Model
+		expectedChecks func(t *testing.T, content string)
+	}{
+		{
+			name: "ViewExecutingAction - Start Pipeline",
+			setupModel: func() *model.Model {
+				m := model.New()
+				m.CurrentView = constants.ViewExecutingAction
+				m.SelectedOperation = &model.Operation{Name: "Start Pipeline"}
+				m.SelectedPipeline = &cloud.PipelineStatus{Name: "test-pipeline"}
+
+				// Set up the table with execution options
+				UpdateTableForView(m)
+
+				return m
+			},
+			expectedChecks: func(t *testing.T, content string) {
+				// Check that the content contains the table rows
+				if !strings.Contains(content, "Execute") {
+					t.Errorf("Expected content to contain 'Execute' row, got '%s'", content)
+				}
+				if !strings.Contains(content, "Cancel") {
+					t.Errorf("Expected content to contain 'Cancel' row, got '%s'", content)
+				}
+
+				// Check that the content does not contain the loading message
+				if strings.Contains(content, "Loading") {
+					t.Errorf("Content should not contain loading message, got '%s'", content)
+				}
+			},
+		},
+		{
+			name: "ViewExecutingAction - Approval",
+			setupModel: func() *model.Model {
+				m := model.New()
+				m.CurrentView = constants.ViewExecutingAction
+				m.SelectedApproval = &cloud.ApprovalAction{
+					PipelineName: "test-pipeline",
+					StageName:    "test-stage",
+					ActionName:   "test-action",
+				}
+				m.ApproveAction = true
+
+				// Set up the table with execution options
+				UpdateTableForView(m)
+
+				return m
+			},
+			expectedChecks: func(t *testing.T, content string) {
+				// Check that the content contains the table rows
+				if !strings.Contains(content, "Execute") {
+					t.Errorf("Expected content to contain 'Execute' row, got '%s'", content)
+				}
+				if !strings.Contains(content, "Cancel") {
+					t.Errorf("Expected content to contain 'Cancel' row, got '%s'", content)
+				}
+
+				// Check that the content does not contain the loading message
+				if strings.Contains(content, "Loading") {
+					t.Errorf("Content should not contain loading message, got '%s'", content)
+				}
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := tc.setupModel()
+			content := renderMainContent(m)
+			tc.expectedChecks(t, content)
+		})
+	}
+}


### PR DESCRIPTION
This commit fixes an issue where the pipeline approval and start pipeline execution views were showing a 'loading...' message instead of the expected table with 'Execute' and 'Cancel' options. The issue was in the renderMainContent function in internal/ui/view/view.go, which was returning m.LoadingMsg for the ViewExecutingAction view instead of rendering the table. The fix changes the function to call renderTable(m) instead, which properly displays the table with execution options.

Added regression tests:
- Unit test in view_test.go to verify the renderMainContent function correctly renders a table
- Enhanced integration tests in aws_pipeline_start_test.go and aws_approvals_test.go to verify the table is displayed correctly

This ensures the execution view will continue to display properly in the future.